### PR TITLE
Android 6. labor typo

### DIFF
--- a/docs/laborok/06-android-room/index.md
+++ b/docs/laborok/06-android-room/index.md
@@ -383,7 +383,7 @@ fun update(shoppingItems: List<ShoppingItem>) {
 
 #### A `RecyclerView` és az adatok megjelenítése
 
-Kezdjük azzal, hogy kiegészítjük a theme.xml fájl tartalmát az alábbira:
+Kezdjük azzal, hogy kiegészítjük a themes.xml fájl tartalmát az alábbira:
 
 ```xml
 <resources xmlns:tools="http://schemas.android.com/tools">


### PR DESCRIPTION
A "theme.xml" file nem létezik, a helyes elnevezés "themes.xml"

![image](https://github.com/VIAUAC00/laborok/assets/127698251/0d96d577-a948-4fed-ac60-abf7c03e0851)

[I53LZ8]