### PR TITLE
Android Room version javaslat

### DIFF
--- a/laborok/06-android-room/index.html
+++ b/laborok/06-android-room/index.html
@@ -1203,7 +1203,7 @@ A menüben található „Remove all” opcióval az összes lista elemet törö
 <p>Ezt követően, szintén ebben a <code>build.gradle.kts</code> fájlban a <code>dependencies</code> blokkhoz adjuk hozzá a <code>Room</code> libraryt:
 <div class="highlight"><pre><span></span><code>dependencies {
     //...
-    val room_version = &quot;2.3.0&quot;
+    val room_version = &quot;2.4.0&quot;
     implementation(&quot;androidx.room:room-runtime:$room_version&quot;)
     implementation(&quot;androidx.room:room-ktx:$room_version&quot;)
     kapt(&quot;androidx.room:room-compiler:$room_version&quot;)


### PR DESCRIPTION
A 2.3-as verziójú Android Room nem kompatibilis ARM chipes Mac-ekkel, a 2.4-es már igen.